### PR TITLE
feat: switch DEFAULT_SHEET_CSV_URL to v2 folded sheet

### DIFF
--- a/apps/huwei_landmarks/config.py
+++ b/apps/huwei_landmarks/config.py
@@ -15,7 +15,7 @@ from . import schema
 # 虎尾地標 Google Sheet 的公開 CSV export URL
 DEFAULT_SHEET_CSV_URL = (
     "https://docs.google.com/spreadsheets/d/"
-    "15Xes5VuHMcg8r-mQesv829VnXU1JR1NUHCtyQfYZhCY/export?format=csv"
+    "1Xcvnj35efvDa1anm7ojOAwRUv6n7hKVhN8UTpb4Fmf8/export?format=csv"
 )
 
 
@@ -85,6 +85,7 @@ def build_pipeline(api_key: str | None = None, csv_path: str | None = None) -> R
     generator = GeminiGenerator(
         api_key=api_key,
         prompt_builder=build_prompt,
+        model="gemini-2.5-flash",
     )
     return RAGPipeline(
         data_source=data_source,


### PR DESCRIPTION
## 背景

把預設 Sheet 從 v1 (70 row, 19 landmarks 散在 22+18+10+...) 換成 v2 摺疊版 (18 row, 一 landmark 一 row)。

## 評測 (跑 19 張 golden photos × 兩版 pipeline)

| | 正確 | 平均延遲 |
|---|------|---------|
| v1 (70 row) | 14/19 (74%) | 11.3s |
| **v2 (18 row)** | **15/19 (79%)** | **9.0s** |

> 鐵橋 (虎尾溪鐵橋 ↔ 虎尾鐵橋 是同一座) 算對的話：v1 16/19, v2 17/19

v2 全面好過 v1。

## 配套

- LINE BOT 部署端同步在 `.env` 加 `LANDMARKS_SHEET_CSV_URL`,立即跑 v2 (不必等 PR merge)
- merge 後新 fork / 新部署直接用 v2

## 不在範圍

- 不改 schema.py 欄位定義
- 不動 retriever / generator
- 4/19 那波 async + stage 2 quick hack 仍歸 issue #6 處理