### PR TITLE
[devops] feat: auto-deploy on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy on merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH into host and redeploy
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd /home/yillkid/workspace/4-learn/rag-kit
+            git fetch origin main
+            git reset --hard origin/main
+            docker compose up -d --build line-bot
+            sleep 5
+            curl -fsS http://localhost:8001/healthz && echo " — BOT healthy"


### PR DESCRIPTION
## Summary

加 `.github/workflows/deploy.yml` — 在 push to main 時透過 SSH 連回 host，跑：
- `git reset --hard origin/main`
- `docker compose up -d --build line-bot`
- `curl /healthz` 驗證

## Why now

明天虎科同學課程要 demo Jules → PR → merge → BOT 變更行為的完整流程。沒有 auto-deploy 的話，merge 後得手動 ssh + rebuild，學生看不到「merge 即生效」的故事。

## 需要的 secrets（已設好）

- DEPLOY_HOST = 35.194.233.225
- DEPLOY_USER = yillkid
- DEPLOY_SSH_KEY = ed25519 private key（public key 已加到 host authorized_keys）

## Test plan

- [ ] Merge 這支 PR
- [ ] 看 Actions 頁面 deploy job 跑成功
- [ ] `docker inspect huwei-landmarks-line-bot --format '{{.State.StartedAt}}'` 顯示新時間戳
- [ ] LINE BOT 仍 healthy（curl healthz 200）

## 後續（separate PR）

明天課堂示範 Jules 改 prompt 修幻覺，merge 後這個 workflow 就會自動更新 BOT。

🤖 Generated with [Claude Code](https://claude.com/claude-code)