### PR TITLE
[devops] feat: auto-deploy on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy on merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH into host and redeploy
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd /home/yillkid/workspace/4-learn/rag-kit
+            git fetch origin main
+            git reset --hard origin/main
+            docker compose up -d --build line-bot
+            sleep 5
+            curl -fsS http://localhost:8001/healthz && echo " — BOT healthy"


### PR DESCRIPTION
## Summary

加 `.github/workflows/deploy.yml` — 在 push to main 時透過 SSH 連回 host，跑 `git pull && docker compose up -d --build line-bot`。

## Why

明天虎科同學課程要 demo Jules → PR → merge → BOT 變更行為的完整流程。同學從 4-learn fork，cross-repo PR 回 4-learn 後，老師 merge 的瞬間 BOT 自動更新。

## Secrets

DEPLOY_HOST / DEPLOY_USER / DEPLOY_SSH_KEY (ed25519) — 已設好。

🤖 Generated with [Claude Code](https://claude.com/claude-code)