### PR TITLE
[rd] feat: friendly LINE reply for out-of-domain photos

### DIFF
--- a/apps/huwei_landmarks/line_bot.py
+++ b/apps/huwei_landmarks/line_bot.py
@@ -143,11 +143,10 @@ def handle_image_message(image_bytes: bytes) -> str:
         return f"辨識失敗：{result['error']}"
 
     name = result.get("name", "").strip()
+    if name == "unknown":
+        return "哎呀，這張我認不太出來是虎尾的地標耶 😅 再傳一張地標的照片給我看看？我對虎尾的 18 個地標比較有把握 📸"
     if not name:
         return "辨識失敗：回傳缺少地點名稱"
-
-    if name == "unknown":
-        return "這張照片不像虎尾的 18 個地標 🤔\n要不要再傳一張地標的照片給我？"
 
     # Stage 2：用 data source 撈完整 row，再讓 Gemini 組人話
     try:

--- a/apps/huwei_landmarks/line_bot.py
+++ b/apps/huwei_landmarks/line_bot.py
@@ -146,6 +146,9 @@ def handle_image_message(image_bytes: bytes) -> str:
     if not name:
         return "辨識失敗：回傳缺少地點名稱"
 
+    if name == "unknown":
+        return "這張照片不像虎尾的 18 個地標 🤔\n要不要再傳一張地標的照片給我？"
+
     # Stage 2：用 data source 撈完整 row，再讓 Gemini 組人話
     try:
         row = pipeline.data_source.by_key(name)


### PR DESCRIPTION
## Why

PR #13 修掉幻覺後，BOT 看到非地標（例：狗）會回 \`name=unknown\`。但 LINE 回覆走 Stage 2 fallback 顯示：

\`\`\`
地點：unknown
（找不到詳細資料）
\`\`\`

像 debug 訊息，使用者體驗差。

## What

在 \`handle_image_message()\` 加一段 short-circuit：\`name == 'unknown'\` 時直接回友善訊息，不走 Stage 2。

\`\`\`
這張照片不像虎尾的 18 個地標 🤔
要不要再傳一張地標的照片給我？
\`\`\`

不影響 in-domain 路徑。

## Test plan

- [ ] Merge → deploy → 傳狗照片 → 看到友善訊息
- [ ] 傳虎尾驛照片 → 仍走 Stage 2 完整導覽

🤖 Generated with [Claude Code](https://claude.com/claude-code)