### PR TITLE
feat: conditional multi-modal via reference_photo_url column

### DIFF
--- a/apps/huwei_landmarks/config.py
+++ b/apps/huwei_landmarks/config.py
@@ -86,6 +86,9 @@ def build_pipeline(api_key: str | None = None, csv_path: str | None = None) -> R
         api_key=api_key,
         prompt_builder=build_prompt,
         model="gemini-2.5-flash",
+        # 條件性多模態:Sheet 有填 reference_photo_url 的 row 才下載比圖
+        reference_photo_column=schema.REFERENCE_PHOTO_COLUMN,
+        key_column=schema.KEY_COLUMN,
     )
     return RAGPipeline(
         data_source=data_source,

--- a/apps/huwei_landmarks/schema.py
+++ b/apps/huwei_landmarks/schema.py
@@ -10,11 +10,12 @@ COL_STRUCT = "建築結構 (struct)"
 COL_MATERIAL = "材質 (material)"
 COL_FUNCTION = "功能用途 (function)"
 COL_SUMMARY = "簡介 (summary)"
+COL_REFERENCE_PHOTO = "reference_photo_url (參考照片)"
 
 # 主鍵欄位
 KEY_COLUMN = COL_NAME
 
-# 所有供 Retriever/Generator 用的特徵欄位
+# 所有供 Retriever/Generator 用的特徵欄位（純文字渲染進 prompt）
 FEATURE_COLUMNS = [
     ("style", COL_STYLE, "風格"),
     ("struct", COL_STRUCT, "結構"),
@@ -22,6 +23,9 @@ FEATURE_COLUMNS = [
     ("function", COL_FUNCTION, "用途"),
     ("summary", COL_SUMMARY, "簡介"),
 ]
+
+# 參考照片欄位（不在 FEATURE_COLUMNS 裡 — 不渲染為文字、改成 inline image）
+REFERENCE_PHOTO_COLUMN = COL_REFERENCE_PHOTO
 
 # summary 截斷長度（避免 prompt 過長）
 SUMMARY_MAX_LEN = 120

--- a/src/rag/generator/gemini.py
+++ b/src/rag/generator/gemini.py
@@ -5,10 +5,16 @@
 從原本的 detect.detect_landmark() 拆出來，讓 Generator 不再綁死地標領域：
 - prompt template 由 app 層（huwei_landmarks）提供
 - 欄位組裝也由 app 層決定
+
+進階功能（v2）：條件性多模態
+- 若 payload 的 row 帶 reference photo URL/path,自動 download + 塞進 prompt
+- 沒帶的 row 走純文字快路徑(向後相容)
 """
 
 import base64
 import json
+import os
+from pathlib import Path
 from typing import Any, Callable
 
 import requests
@@ -22,6 +28,9 @@ class GeminiGenerator:
         model:   Gemini 模型名稱（預設 gemini-2.5-flash）
         prompt_builder: callable(payload, query) -> str，組出 prompt 文字
         response_mime_type: 預設 "application/json"
+        reference_photo_column: 選填,row dict 中存 reference photo URL/path 的 key
+        key_column: 選填,row dict 中存地標名的 key(用來標 reference 是哪個地標)
+        reference_timeout_sec: download reference photo 的 timeout
     """
 
     API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
@@ -32,20 +41,87 @@ class GeminiGenerator:
         prompt_builder: Callable[[dict, Any], str],
         model: str = "gemini-2.5-flash",
         response_mime_type: str = "application/json",
+        reference_photo_column: str | None = None,
+        key_column: str | None = None,
+        reference_timeout_sec: float = 10.0,
     ):
         self.api_key = api_key
         self.model = model
         self.prompt_builder = prompt_builder
         self.response_mime_type = response_mime_type
+        self.reference_photo_column = reference_photo_column
+        self.key_column = key_column
+        self.reference_timeout_sec = reference_timeout_sec
+        # In-memory cache: ref source(URL/path) → (bytes, mime)
+        self._ref_cache: dict[str, tuple[bytes, str]] = {}
+
+    def _fetch_reference(self, source: str) -> tuple[bytes, str] | None:
+        """下載/讀取 reference photo,回 (bytes, mime_type)。失敗回 None。"""
+        if source in self._ref_cache:
+            return self._ref_cache[source]
+
+        try:
+            if source.startswith(("http://", "https://")):
+                resp = requests.get(source, timeout=self.reference_timeout_sec)
+                resp.raise_for_status()
+                content = resp.content
+                mime = resp.headers.get("Content-Type", "image/jpeg")
+                # 有時 Content-Type 帶 ; charset=...,只取前段
+                mime = mime.split(";", 1)[0].strip()
+            else:
+                # 視為 local path
+                p = Path(source)
+                if not p.exists():
+                    return None
+                content = p.read_bytes()
+                ext = p.suffix.lower()
+                mime = "image/png" if ext == ".png" else "image/jpeg"
+        except Exception:
+            return None
+
+        self._ref_cache[source] = (content, mime)
+        return content, mime
+
+    def _build_reference_parts(self, rows: list[dict]) -> list[dict]:
+        """掃 rows,有 reference 就加進 parts。沒設 reference_photo_column 時直接回 []。"""
+        if not self.reference_photo_column:
+            return []
+        parts: list[dict] = []
+        for row in rows:
+            ref = (row.get(self.reference_photo_column) or "").strip()
+            if not ref:
+                continue
+            fetched = self._fetch_reference(ref)
+            if not fetched:
+                continue
+            content, mime = fetched
+            name = (
+                (row.get(self.key_column) or "").strip()
+                if self.key_column
+                else "(unknown)"
+            )
+            parts.append({"text": f"\n[reference photo of 「{name}」]"})
+            parts.append({
+                "inline_data": {
+                    "mime_type": mime,
+                    "data": base64.b64encode(content).decode(),
+                }
+            })
+        return parts
 
     def generate(self, payload: dict, query: Any) -> str:
         prompt_text = self.prompt_builder(payload, query)
 
         parts: list[dict] = [{"text": prompt_text}]
 
+        # 條件性多模態:有 reference photo 的 row 加進 prompt
+        ref_parts = self._build_reference_parts(payload.get("rows", []))
+        parts.extend(ref_parts)
+
         # query 支援 {"image_bytes": bytes, "mime_type": "image/png"} 或 str
         if isinstance(query, dict) and "image_bytes" in query:
             img_b64 = base64.b64encode(query["image_bytes"]).decode()
+            parts.append({"text": "\n[使用者照片]"})
             parts.append({
                 "inline_data": {
                     "mime_type": query.get("mime_type", "image/png"),


### PR DESCRIPTION
## Why

Ch4 教學素材 — Sheet 加新 column `reference_photo_url`,讓視覺極度相似的地標（涌翠閣 vs 第三公差 vs 雲林故事館）能用「**reference photo 比對**」分開。

3 trials 穩定性實測：

| 失敗照 | Ch3 純文字 | + reference photo |
|---|---|---|
| 涌翠閣-1 | 67% (2/3) | **100%** (3/3) ✅ |
| 第三公差-1 | 33% (1/3) | **100%** (3/3) ✅ |

→ mutual confusion pair 從機率性救升級為穩定救。

## What

3 個檔案 ~84 行：

### `apps/huwei_landmarks/schema.py`（+5）
新 const `COL_REFERENCE_PHOTO` + `REFERENCE_PHOTO_COLUMN`。**不放 FEATURE_COLUMNS** — 不渲染為文字，改成 inline image。

### `apps/huwei_landmarks/config.py`（+3）
`build_pipeline()` 把 `reference_photo_column` / `key_column` 傳給 generator。

### `src/rag/generator/gemini.py`（+76）
- 新 params：`reference_photo_column` / `key_column` / `reference_timeout_sec`（皆選填、預設 None = backward compat）
- `_fetch_reference()`：URL（download）或 local path（read），含 in-memory cache
- `_build_reference_parts()`：掃 `payload[\"rows\"]`、有填 ref 的就加 inline_data part
- 條件性：沒填 ref 的 row → 不下載、不塞圖、走純文字快路徑

## Test plan

- [x] In-memory test 3 trials × 4 hard photos：涌翠閣 + 第三公差 都 100% 穩
- [x] In-domain photos 不被破壞
- [x] Reference 用 local golden file 模擬，等 Sheet 加 column 後 URL 切換無縫
- [ ] 上 PA 後 download Drive URL（等 Sheet column + 文史組上傳照片）

## 為什麼這個設計乾淨

- ✅ **條件性多模態**：18 地標只 ~3 個需要 ref，cost 不爆
- ✅ **新 column 不改舊**：純加性、不破壞現有 row
- ✅ **URL 而不是檔案**：文史組 Drive 自由換照片、不用碰程式
- ✅ **Backward compat**：`reference_photo_column=None` = 行為跟之前一樣

🤖 Generated with [Claude Code](https://claude.com/claude-code)